### PR TITLE
Update the name of scikit-learn in setup.py as 'sklearn' is not used anymore

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,11 +7,11 @@ setup(
     author_email="nicolas@seita.nl",
     url="https://github.com/seitabv/timetomodel",
     keywords=["time series", "forecasting"],
-    version="0.7.1",
+    version="0.7.2",
     install_requires=[
         "pandas",
         "statsmodels",
-        "sklearn",
+        "scikit-learn",
         "matplotlib",
         "numpy",
         "scipy",


### PR DESCRIPTION
Here is the message you now get when you pip install sklearn:

```
The 'sklearn' PyPI package is deprecated, use 'scikit-learn'
      rather than 'sklearn' for pip commands.
      
      Here is how to fix this error in the main use cases:
      - use 'pip install scikit-learn' rather than 'pip install sklearn'
      - replace 'sklearn' by 'scikit-learn' in your pip requirements files
        (requirements.txt, setup.py, setup.cfg, Pipfile, etc ...)
      - if the 'sklearn' package is used by one of your dependencies,
        it would be great if you take some time to track which package uses
        'sklearn' instead of 'scikit-learn' and report it to their issue tracker
      - as a last resort, set the environment variable
        SKLEARN_ALLOW_DEPRECATED_SKLEARN_PACKAGE_INSTALL=True to avoid this error
      
      More information is available at
      https://github.com/scikit-learn/sklearn-pypi-package
```